### PR TITLE
Fix handling tags namespaces

### DIFF
--- a/packages/hast-util-from-webparser/index.ts
+++ b/packages/hast-util-from-webparser/index.ts
@@ -164,7 +164,13 @@ function element(
   config: TransformOptions
 ): HastNode {
   const fn = config.schema.space === 'svg' ? hastSvg : hast
-  const name = getNameAndNS(ast.name).name
+  const elementInfo = getNameAndNS(ast.name)
+  // Handle namespaces in tags, but skip it if it's the same as tag name
+  // i.e. :svg:g -> svg:g, but :svg:svg -> svg
+  const name =
+    elementInfo.ns && elementInfo.ns !== elementInfo.name
+      ? elementInfo.ns + ':' + elementInfo.name
+      : elementInfo.name
   const props: { [name: string]: string } = {}
   let node
 

--- a/packages/hast-util-from-webparser/test/__snapshots__/index.test.ts.snap
+++ b/packages/hast-util-from-webparser/test/__snapshots__/index.test.ts.snap
@@ -691,7 +691,7 @@ Object {
                 "fill": "red",
                 "r": "50",
               },
-              "tagName": "circle",
+              "tagName": "svg:circle",
               "type": "element",
             },
             Object {
@@ -734,7 +734,7 @@ Object {
                 "fill": "green",
                 "r": "50",
               },
-              "tagName": "circle",
+              "tagName": "svg:circle",
               "type": "element",
             },
             Object {
@@ -806,6 +806,204 @@ Object {
           "column": 6,
           "line": 5,
           "offset": 254,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 0,
+          "offset": 0,
+        },
+      },
+      "properties": Object {},
+      "tagName": "div",
+      "type": "element",
+    },
+  ],
+  "data": Object {
+    "selfClosing": false,
+  },
+  "type": "root",
+}
+`;
+
+exports[`SVG namespace 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 2,
+              "line": 1,
+              "offset": 8,
+            },
+            "start": Object {
+              "column": 5,
+              "line": 0,
+              "offset": 5,
+            },
+          },
+          "type": "text",
+          "value": "
+  ",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "position": Object {
+                "end": Object {
+                  "column": 4,
+                  "line": 2,
+                  "offset": 143,
+                },
+                "start": Object {
+                  "column": 132,
+                  "line": 1,
+                  "offset": 138,
+                },
+              },
+              "type": "text",
+              "value": "
+    ",
+            },
+            Object {
+              "children": Array [],
+              "data": Object {
+                "selfClosing": true,
+              },
+              "position": Object {
+                "end": Object {
+                  "column": 52,
+                  "line": 2,
+                  "offset": 191,
+                },
+                "start": Object {
+                  "column": 4,
+                  "line": 2,
+                  "offset": 143,
+                },
+              },
+              "properties": Object {
+                "cx": "60",
+                "cy": "60",
+                "fill": "red",
+                "r": "50",
+              },
+              "tagName": "svg:circle",
+              "type": "element",
+            },
+            Object {
+              "position": Object {
+                "end": Object {
+                  "column": 4,
+                  "line": 3,
+                  "offset": 196,
+                },
+                "start": Object {
+                  "column": 52,
+                  "line": 3,
+                  "offset": 191,
+                },
+              },
+              "type": "text",
+              "value": "
+    ",
+            },
+            Object {
+              "children": Array [],
+              "data": Object {
+                "selfClosing": true,
+              },
+              "position": Object {
+                "end": Object {
+                  "column": 54,
+                  "line": 3,
+                  "offset": 246,
+                },
+                "start": Object {
+                  "column": 4,
+                  "line": 3,
+                  "offset": 196,
+                },
+              },
+              "properties": Object {
+                "cx": "170",
+                "cy": "60",
+                "fill": "green",
+                "r": "50",
+              },
+              "tagName": "svg:circle",
+              "type": "element",
+            },
+            Object {
+              "position": Object {
+                "end": Object {
+                  "column": 2,
+                  "line": 4,
+                  "offset": 249,
+                },
+                "start": Object {
+                  "column": 54,
+                  "line": 4,
+                  "offset": 246,
+                },
+              },
+              "type": "text",
+              "value": "
+  ",
+            },
+          ],
+          "data": Object {
+            "selfClosing": false,
+          },
+          "position": Object {
+            "end": Object {
+              "column": 8,
+              "line": 4,
+              "offset": 255,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 1,
+              "offset": 8,
+            },
+          },
+          "properties": Object {
+            "height": "120",
+            "viewBox": "0 0 200 200",
+            "width": "230",
+            "xmlns": "http://www.w3.org/2000/svg",
+            "xmlnsXLink": "http://www.w3.org/1999/xlink",
+          },
+          "tagName": "svg",
+          "type": "element",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 0,
+              "line": 5,
+              "offset": 256,
+            },
+            "start": Object {
+              "column": 8,
+              "line": 4,
+              "offset": 255,
+            },
+          },
+          "type": "text",
+          "value": "
+",
+        },
+      ],
+      "data": Object {
+        "selfClosing": false,
+      },
+      "position": Object {
+        "end": Object {
+          "column": 6,
+          "line": 5,
+          "offset": 262,
         },
         "start": Object {
           "column": 0,

--- a/packages/hast-util-from-webparser/test/index.test.ts
+++ b/packages/hast-util-from-webparser/test/index.test.ts
@@ -68,6 +68,25 @@ test('SVG', () => {
   expect(node).toMatchSnapshot()
 })
 
+test('SVG namespace', () => {
+  const parser = new HtmlParser()
+  const result = parser.parse(
+    `<div>
+  <svg width="230" height="120" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <svg:circle cx="60"  cy="60" r="50" fill="red"/>
+    <svg:circle cx="170" cy="60" r="50" fill="green"/>
+  </svg>
+</div>`,
+    'TestComp'
+  )
+
+  expect(result.errors.length).toBe(0)
+
+  const node = fromWebParser(result.rootNodes, {})
+
+  expect(node).toMatchSnapshot()
+})
+
 test('Template', () => {
   const parser = new HtmlParser()
   const result = parser.parse(

--- a/packages/prettyhtml-formatter/test/fixtures/tag-namespace/input.html
+++ b/packages/prettyhtml-formatter/test/fixtures/tag-namespace/input.html
@@ -1,0 +1,1 @@
+<svg:g>foo</svg:g>

--- a/packages/prettyhtml-formatter/test/fixtures/tag-namespace/output.html
+++ b/packages/prettyhtml-formatter/test/fixtures/tag-namespace/output.html
@@ -1,0 +1,1 @@
+<svg:g>foo</svg:g>


### PR DESCRIPTION
The PR fixes missing tag namespaces in generated HTML and resolve problems with [Angular SVG namespaces](https://teropa.info/blog/2016/12/12/graphics-in-angular-2.html).