### PR TITLE
Include d.ts file in npm distribution. Fix #35

### DIFF
--- a/packages/prettyhtml/package.json
+++ b/packages/prettyhtml/package.json
@@ -8,6 +8,7 @@
     "url": "git+https://github.com/StarpTech/prettyhtml.git"
   },
   "bin": "cli.js",
+  "types": "./index.d.ts",
   "scripts": {
     "test": "echo 'no tests defined'"
   },
@@ -15,7 +16,8 @@
     "index.js",
     "cli.js",
     "defaults.js",
-    "lib"
+    "lib",
+    "index.d.ts"
   ],
   "keywords": [
     "formatter",


### PR DESCRIPTION
Also btw, I don't see any `defaults.js` or `lib` in the dist any more for the package `prettyhtml`. Maybe also remove them?