### PR TITLE
Mark `prettier` option as optional

### DIFF
--- a/packages/prettyhtml/index.d.ts
+++ b/packages/prettyhtml/index.d.ts
@@ -9,7 +9,7 @@ declare function prettyhtml(
     printWidth?: number
     usePrettier?: boolean
     singleQuote?: boolean
-    prettier: {
+    prettier?: {
       tabWidth?: number
       useTabs?: boolean
       printWidth?: number


### PR DESCRIPTION
As far as I can see, you can provide the option without specifying `prettier`.