### PR TITLE
fix: image tag format throw error

### DIFF
--- a/packages/prettyhtml-formatter/index.js
+++ b/packages/prettyhtml-formatter/index.js
@@ -283,7 +283,11 @@ function startsWithNewline(node) {
 function handleTemplateExpression(child, children) {
   if (isTemplateExpression(child.value)) {
     // dont touch nodes with single text element
-    if (containsOnlyTextNodes({ children })) {
+    if (
+      containsOnlyTextNodes({
+        children
+      })
+    ) {
       return false
     }
 
@@ -467,12 +471,21 @@ function prettierEmbeddedContent(node, level, indent, prettierOpts) {
         prettierOpts
       )
     )
-    formattedText = indentPrettierOutput(formattedText, level)
+    formattedText = indentPrettierOutput(formattedText, level, indent)
 
     node.children = [
-      { type: 'text', value: single },
-      { type: 'text', value: formattedText },
-      { type: 'text', value: repeat(indent, level - 1) }
+      {
+        type: 'text',
+        value: single
+      },
+      {
+        type: 'text',
+        value: formattedText
+      },
+      {
+        type: 'text',
+        value: repeat(indent, level - 1)
+      }
     ]
   } else if (isElement(node, 'script')) {
     const content = toString(node)
@@ -505,25 +518,34 @@ function prettierEmbeddedContent(node, level, indent, prettierOpts) {
         prettierOpts
       )
     )
-    formattedText = indentPrettierOutput(formattedText, level)
+    formattedText = indentPrettierOutput(formattedText, level, indent)
     // in order to prevent parsing issues
     // https://github.com/inikulin/parse5/issues/262
     formattedText = formattedText.replace(/<\/script\s*>/g, '<\\/script>')
 
     node.children = [
-      { type: 'text', value: single },
-      { type: 'text', value: formattedText },
-      { type: 'text', value: repeat(indent, level - 1) }
+      {
+        type: 'text',
+        value: single
+      },
+      {
+        type: 'text',
+        value: formattedText
+      },
+      {
+        type: 'text',
+        value: repeat(indent, level - 1)
+      }
     ]
   }
 }
 
-function indentPrettierOutput(formattedText, level) {
+function indentPrettierOutput(formattedText, level, indent) {
   let lines = formattedText.split(single)
 
   for (let i = 0; i < lines.length; i++) {
     if (lines[i].replace(/\s+/g, '').length) {
-      lines[i] = repeat('  ', level) + lines[i]
+      lines[i] = repeat(indent, level) + lines[i]
     }
   }
 

--- a/packages/prettyhtml-formatter/test/fixtures/image-tag/input.html
+++ b/packages/prettyhtml-formatter/test/fixtures/image-tag/input.html
@@ -1,0 +1,6 @@
+<div>
+  <svg>
+    <image src="http://google.com"></image>
+  </svg>
+  <image src="http://google.com">
+</div>

--- a/packages/prettyhtml-formatter/test/fixtures/image-tag/output.html
+++ b/packages/prettyhtml-formatter/test/fixtures/image-tag/output.html
@@ -1,0 +1,6 @@
+<div>
+  <svg>
+    <image src="http://google.com"></image>
+  </svg>
+  <image src="http://google.com">
+</div>

--- a/packages/webparser/src/html_tags.ts
+++ b/packages/webparser/src/html_tags.ts
@@ -95,6 +95,7 @@ export function getHtmlTagDefinition(
       embed: new HtmlTagDefinition({ isVoid: true, canSelfClose }),
       link: new HtmlTagDefinition({ isVoid: true, canSelfClose }),
       img: new HtmlTagDefinition({ isVoid: true, canSelfClose }),
+      image: new HtmlTagDefinition({ isVoid: true, canSelfClose }),
       input: new HtmlTagDefinition({ isVoid: true, canSelfClose }),
       param: new HtmlTagDefinition({ isVoid: true, canSelfClose }),
       hr: new HtmlTagDefinition({ isVoid: true, canSelfClose }),

--- a/packages/webparser/test/parser.spec.ts
+++ b/packages/webparser/test/parser.spec.ts
@@ -197,6 +197,43 @@ import {
           ])
         })
 
+        it('should parse image with closed tag in svg space', () => {
+          expect(
+            humanizeDom(
+              parser.parse(
+                '<svg><image src="http://image.de"></image></svg>',
+                'TestComp'
+              )
+            )
+          ).toEqual([
+            [html.Element, ':svg:svg', 0, true],
+            [html.Element, ':svg:image', 1, true],
+            [html.Attribute, 'src', 'http://image.de']
+          ])
+        })
+
+        it('should parse image as void element in html space', () => {
+          expect(
+            humanizeDom(
+              parser.parse('<image src="http://image.de">', 'TestComp')
+            )
+          ).toEqual([
+            [html.Element, 'image', 0],
+            [html.Attribute, 'src', 'http://image.de']
+          ])
+        })
+
+        it('should error when image is used with closed tag in html space', () => {
+          const errors = parser.parse(
+            '<image src="http://image.de"></image>',
+            'TestComp'
+          ).errors
+          expect(errors.length).toEqual(1)
+          expect(humanizeErrors(errors)).toEqual([
+            ['image', 'Void elements do not have end tags "image"', '0:29']
+          ])
+        })
+
         it('should not error on void elements from HTML5 spec', () => {
           // http://www.w3.org/TR/html-markup/syntax.html#syntax-elements without:
           // <base> - it can be present in head only

--- a/packages/webparser/test/parser.spec.ts
+++ b/packages/webparser/test/parser.spec.ts
@@ -210,6 +210,7 @@ import {
             '<div><embed></div>',
             '<div><hr></div>',
             '<div><img></div>',
+            '<div><image></div>',
             '<div><input></div>',
             '<object><param>/<object>',
             '<audio><source></audio>',


### PR DESCRIPTION
fix #72 

Hi,I don't think image should a valid tag in html, so I remove the void tag from html-void-elements.

here are the expected examples:

input: 
 ```html
<template>
  <div>
    <image src="http://google.com" />
  </div>
</template>
```

output:

```html
<template>
  <div>
    <image src="http://google.com" />
  </div>
</template>

```


or,input:


```html
    <image src="http://google.com"></image>

```

output:

```html
   <image src="http://google.com"></image>
```

or ,input : 

```html
<image src="">
```

output:

```html
<image src="" />
```