### PR TITLE
Added missing dependency in package.json for prettyhtml-hast-to-html

### DIFF
--- a/packages/prettyhtml-hast-to-html/package.json
+++ b/packages/prettyhtml-hast-to-html/package.json
@@ -35,6 +35,7 @@
     "html-void-elements": "^1.0.3",
     "html-whitespace-sensitive-tag-names": "^1.0.0",
     "property-information": "^5.0.1",
+    "repeat-string": "^1.6.1",
     "space-separated-tokens": "^1.1.2",
     "stringify-entities": "^1.3.2",
     "unist-util-is": "^2.1.2",


### PR DESCRIPTION
Hi, we are using ``prettyhtml-hast-to-html`` in our application and there is small missing dependency in the ``package.json`` of ``prettyhtml-hast-to-html``. A ``repeat-string`` dependency is being used in ``element.js`` file here --> https://github.com/Prettyhtml/prettyhtml/blob/master/packages/prettyhtml-hast-to-html/lib/element.js#L11

But it is missing in [package.json](https://github.com/Prettyhtml/prettyhtml/blob/master/packages/prettyhtml-hast-to-html/package.json) so when we are using ``prettyhtml-hast-to-html`` alone, users will run into this issue.