### PR TITLE
(prettyhtml-quick) Fix error when not in the project's root folder

### DIFF
--- a/packages/prettyhtml-quick/bin/cli.js
+++ b/packages/prettyhtml-quick/bin/cli.js
@@ -49,7 +49,7 @@ htmlFiles.forEach(file => {
   try {
     const vFile = prettyhtml(input, prettyhtmlCfg)
     fs.writeFileSync(filePath, vFile.contents, 'utf8')
-    git.stageFile(cwd, file)
+    git.stageFile(root, file)
     console.log(`✍️  Fixing up ${chalk.bold(file)}.`)
   } catch (error) {
     console.log(`❌  Error: ${chalk.bold(error.message)}.`)

--- a/packages/prettyhtml-quick/lib/git.js
+++ b/packages/prettyhtml-quick/lib/git.js
@@ -5,9 +5,11 @@ const path = require('path')
 const findUp = require('find-up')
 
 module.exports.detect = directory => {
-  const gitDirectory = findUp.sync('.git', { cwd: directory })
+  const gitDirectory = findUp.sync('.git', {cwd: directory, type: 'directory'})
   if (gitDirectory) {
     return path.dirname(gitDirectory)
+  } else {
+    throw new Error('Could not find git repository');
   }
 }
 


### PR DESCRIPTION
Hi there,

I have tried to use prettyhtml-quick for linting my staged files.
I have noticed there is an error when I am not in the root of the project, so found out there were two issue with the package.

I thought it was a good idea creating a PR.

Issue no.1: findUp is looking for files rather than directory
Issue no.2: Git stage is staging using user's pwd rathen then project root

