### PR TITLE
Fix circular dependency in prettyhtml-hast-to-html

### DIFF
--- a/packages/prettyhtml-hast-to-html/lib/all.js
+++ b/packages/prettyhtml-hast-to-html/lib/all.js
@@ -6,7 +6,7 @@ var sensitive = require('html-whitespace-sensitive-tag-names')
 module.exports = all
 
 /* Stringify all children of `parent`. */
-function all(ctx, parent) {
+function all(ctx, handlers, parent) {
   var children = parent && parent.children
   var length = children && children.length
   var index = -1
@@ -16,7 +16,7 @@ function all(ctx, parent) {
   let innerTextLength = 0
   while (++index < length) {
     innerTextLength = getInnerTextLength(children[index])
-    results[index] = one(ctx, children[index], index, parent, printWidthOffset, innerTextLength)
+    results[index] = one(ctx, handlers, children[index], index, parent, printWidthOffset, innerTextLength)
     printWidthOffset = results[index].replace(/\n+/g, '').length
   }
 

--- a/packages/prettyhtml-hast-to-html/lib/comment.js
+++ b/packages/prettyhtml-hast-to-html/lib/comment.js
@@ -3,6 +3,6 @@
 module.exports = comment
 
 /* Stringify a comment `node`. */
-function comment(ctx, node) {
+function comment(ctx, handlers, node) {
   return '<!--' + node.value + '-->'
 }

--- a/packages/prettyhtml-hast-to-html/lib/doctype.js
+++ b/packages/prettyhtml-hast-to-html/lib/doctype.js
@@ -3,7 +3,7 @@
 module.exports = doctype
 
 /* Stringify a doctype `node`. */
-function doctype(ctx, node) {
+function doctype(ctx, handlers, node) {
   var sep = ctx.tightDoctype ? '' : ' '
   var name = node.name
   var pub = node.public

--- a/packages/prettyhtml-hast-to-html/lib/element.js
+++ b/packages/prettyhtml-hast-to-html/lib/element.js
@@ -26,7 +26,7 @@ var slash = '/'
 var newLine = '\n'
 
 /* Stringify an element `node`. */
-function element(ctx, node, index, parent, printWidthOffset, innerTextLength) {
+function element(ctx, handlers, node, index, parent, printWidthOffset, innerTextLength) {
   var parentSchema = ctx.schema
   var name = node.tagName
   var value = ''
@@ -100,7 +100,7 @@ function element(ctx, node, index, parent, printWidthOffset, innerTextLength) {
 
   const shouldCollapse = ignoreAttrCollapsing === false && printContext.wrapAttributes
 
-  content = all(ctx, root)
+  content = all(ctx, handlers, root)
 
   /* If the node is categorised as void, but it has
    * children, remove the categorisation.  This

--- a/packages/prettyhtml-hast-to-html/lib/handlers.js
+++ b/packages/prettyhtml-hast-to-html/lib/handlers.js
@@ -1,0 +1,12 @@
+'use strict'
+
+var handlers = {}
+
+handlers.root = require('./all')
+handlers.text = require('./text')
+handlers.element = require('./element')
+handlers.doctype = require('./doctype')
+handlers.comment = require('./comment')
+handlers.raw = require('./raw')
+
+module.exports = handlers

--- a/packages/prettyhtml-hast-to-html/lib/index.js
+++ b/packages/prettyhtml-hast-to-html/lib/index.js
@@ -6,6 +6,7 @@ var voids = require('html-void-elements')
 var omission = require('./omission')
 var one = require('./one')
 const repeat = require('repeat-string')
+var handlers = require('./handlers')
 
 module.exports = toHTML
 
@@ -46,6 +47,7 @@ function toHTML(node, options) {
       tightClose: settings.tightSelfClosing,
       closeEmpty: settings.closeEmptyElements
     },
+    handlers,
     node
   )
 }

--- a/packages/prettyhtml-hast-to-html/lib/one.js
+++ b/packages/prettyhtml-hast-to-html/lib/one.js
@@ -4,17 +4,8 @@ module.exports = one
 
 var own = {}.hasOwnProperty
 
-var handlers = {}
-
-handlers.root = require('./all')
-handlers.text = require('./text')
-handlers.element = require('./element')
-handlers.doctype = require('./doctype')
-handlers.comment = require('./comment')
-handlers.raw = require('./raw')
-
 /* Stringify `node`. */
-function one(ctx, node, index, parent, printWidthOffset, innerTextLength) {
+function one(ctx, handlers, node, index, parent, printWidthOffset, innerTextLength) {
   var type = node && node.type
 
   if (!type) {
@@ -24,6 +15,5 @@ function one(ctx, node, index, parent, printWidthOffset, innerTextLength) {
   if (!own.call(handlers, type)) {
     throw new Error('Cannot compile unknown node `' + type + '`')
   }
-
-  return handlers[type](ctx, node, index, parent, printWidthOffset, innerTextLength)
+  return handlers[type](ctx, handlers, node, index, parent, printWidthOffset, innerTextLength)
 }

--- a/packages/prettyhtml-hast-to-html/lib/raw.js
+++ b/packages/prettyhtml-hast-to-html/lib/raw.js
@@ -3,6 +3,6 @@
 module.exports = raw
 
 /* Stringify `raw`. */
-function raw(ctx, node) {
+function raw(ctx, handlers, node) {
   return node.value
 }

--- a/packages/prettyhtml-hast-to-html/lib/text.js
+++ b/packages/prettyhtml-hast-to-html/lib/text.js
@@ -3,7 +3,7 @@
 module.exports = text
 
 /* Stringify `text`. */
-function text(ctx, node, index, parent) {
+function text(ctx, handlers, node, index, parent) {
   var value = node.value
 
   return value


### PR DESCRIPTION
The "all" module depended on the "one" module and vice versa.
Fix this by defining the functionality needed by "one" (a set of
handlers) in a seperate object which we can pass around.

This circular dependency could cause the library to fail in some
cases, depending on how it was bundled.
